### PR TITLE
Update rate limits per tier example with tiered rate limits

### DIFF
--- a/9.rate-limits-per-tier/README.md
+++ b/9.rate-limits-per-tier/README.md
@@ -1,7 +1,7 @@
 # KrakenD API Gateway - Custom Rate Limiting PoC
 
 ## Overview
-This repo tries to implement custom rate limits for different user tiers in the KrakenD API Gateway, using API keys. The KrakenD configuration file demonstrates the usage of tiered ratelimits introduced int the [2.7 enterprise version](https://krakend.io/blog/krakend-ee-2.7-release-notes).
+This repo tries to implement custom rate limits for different user tiers in the KrakenD API Gateway, using API keys. The KrakenD configuration file demonstrates the usage of tiered ratelimits introduced in the [2.7 enterprise version](https://krakend.io/blog/krakend-ee-2.7-release-notes).
 
 ### Configuration File Description
 The KrakenD configuration file, `krakend.json`, is tailored for applying different rate limits based on user tiers (gold and silver) when using API keys.

--- a/9.rate-limits-per-tier/README.md
+++ b/9.rate-limits-per-tier/README.md
@@ -1,17 +1,21 @@
 # KrakenD API Gateway - Custom Rate Limiting PoC
 
 ## Overview
-This repo tries to implement custom rate limits for different user tiers in the KrakenD API Gateway, using API keys. The KrakenD configuration file demonstrates a possible method, using Lua and internal endpoints, to achieve this functionality.
+This repo tries to implement custom rate limits for different user tiers in the KrakenD API Gateway, using API keys. The KrakenD configuration file demonstrates the usage of tiered ratelimits introduced int the [2.7 enterprise version](https://krakend.io/blog/krakend-ee-2.7-release-notes).
 
 ### Configuration File Description
 The KrakenD configuration file, `krakend.json`, is tailored for applying different rate limits based on user tiers (gold and silver) when using API keys.
 
 #### Key Components:
-- **auth/API-Keys**: Defines API keys for gold and silver user tiers.
-- **endpoints**: Configures the main endpoint `/test` and two internal endpoints for gold and silver tiers.
 
-#### Method for Implementing Custom Rate Limits:
-**URL Modification with Lua Scripting**: Involves modifying the URL by appending the user tier at the end using Lua scripting at the backend level.
+- **auth/API-Keys**: Defines API keys for gold and silver user tiers (roles).
+- `qos/ratelimit/tiered`: to define the ratelimit to apply to each defined tier.
+- **endpoints**: Configures the main endpoint `/test` and the `qos/ratelimit/tiered`.
+
+#### Notes:
+
+Take into account that the role will be the first that matches the list of provided roles 
+inside the endpoint's `extra_config` -> `auth/api-keys`. 
 
 ### Setup Instructions
 1. **Install & Run KrakenD using Docker**:
@@ -34,3 +38,10 @@ To test the rate limiting, use the following curl commands:
   ```
 
 Observe the rate limiting behavior based on the user tier.
+
+#### Us the `hey` tool to use parallel requests
+
+Download the [hey tool from github](https://github.com/rakyll/hey) and edit the `hey.sh`
+bash script to update the env var with the path of the `hey` executable.
+
+Then run the hey script to execute requests in parallel.

--- a/9.rate-limits-per-tier/curl.sh
+++ b/9.rate-limits-per-tier/curl.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+export TEST_URL='http://localhost:8080/test' 
+echo -e "\nTesting GOLD tier:\n"
+export HEADER_AUTHORIZATION="Authorization: Bearer gold-4d2c61e1-34c4-e96c-9456-15bd983c50"
+
+curl \
+    -H "${HEADER_AUTHORIZATION}" \
+    $TEST_URL
+

--- a/9.rate-limits-per-tier/hey.sh
+++ b/9.rate-limits-per-tier/hey.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# TODO: down here the path to your "hey" executable:
+# https://github.com/rakyll/hey
+export HEY_BIN="./hey_linux_amd64"
+export TEST_URL='http://localhost:8080/test' 
+
+echo -e "\nTesting GOLD tier:\n"
+export HEADER_AUTHORIZATION="Authorization: Bearer gold-4d2c61e1-34c4-e96c-9456-15bd983c50"
+$HEY_BIN -n 20 -c 10 \
+    -H "${HEADER_AUTHORIZATION}" \
+    $TEST_URL
+
+
+echo -e "\n\nTesting SILVER tier:\n"
+export HEADER_AUTHORIZATION="Authorization: Bearer silver-4d2c61e1-34c4-e96c-9456-15bd983c50"
+$HEY_BIN -n 20 -c 10 \
+    -H "${HEADER_AUTHORIZATION}" \
+    $TEST_URL

--- a/9.rate-limits-per-tier/krakend.json
+++ b/9.rate-limits-per-tier/krakend.json
@@ -7,6 +7,7 @@
   "echo_endpoint": true,
   "extra_config": {
     "auth/api-keys": {
+      "propagate_role": "X-Krakend-Role",
       "keys": [
         {
           "key": "gold-4d2c61e1-34c4-e96c-9456-15bd983c50",
@@ -22,49 +23,42 @@
   "endpoints": [
     {
       "endpoint": "/test",
-      "input_headers": ["Authorization"],
+      "input_headers": ["Authorization", "X-Krakend-Role"],
       "backend": [
         {
-          "url_pattern": "/__internal/test",
-          "extra_config": {
-            "modifier/lua-backend": {
-              "@comment": "Modify the current URL adding the tier at the end.",
-              "pre": "local r=request.load();local api_key=r:headers('Authorization');local tier=api_key:match('Bearer%s+(%w+)-');local url=r:url();r:url( url..'-'..tier);",
-              "allow_open_libs": true,
-              "live": true
-            }
-          }
+          "url_pattern": "/__debug"
         }
       ],
       "extra_config": {
         "auth/api-keys": {
-          "roles": ["user"]
-        }
-      }
-    },
-    {
-      "@comment": "Internal endpoint, just to configure client max rate to 3, for gold users.",
-      "endpoint": "/__internal/test-gold",
-      "backend": [
-        {"url_pattern": "/__debug/"}
-      ],
-      "extra_config": {
-        "auth/api-keys": {
-          "roles": ["gold"],
-          "client_max_rate": 3
-        }
-      }
-    },
-    {
-      "@comment": "Internal endpoint, just to configure client max rate to 1, for silver users.",
-      "endpoint": "/__internal/test-silver",
-      "backend": [
-        {"url_pattern": "/__debug/"}
-      ],
-      "extra_config": {
-        "auth/api-keys": {
-          "roles": ["silver"],
-          "client_max_rate": 1
+          "roles": ["gold", "silver"]
+        },
+        "qos/ratelimit/tiered": {
+            "tier_key": "X-Krakend-Role",
+            "tiers": [
+                {
+                    "tier_value": "gold",
+                    "tier_value_as": "literal",
+                    "ratelimit": {
+                        "client_max_rate": 10,
+                        "client_capacity": 10,
+                        "every": "10s",
+                        "strategy": "header",
+                        "key": "Authorization"
+                    }
+                },
+                {
+                    "tier_value": "value.matches('silver.*')",
+                    "tier_value_as": "policy",
+                    "ratelimit": {
+                        "client_max_rate": 5,
+                        "client_capacity": 5,
+                        "every": "10s",
+                        "strategy": "header",
+                        "key": "Authorization"
+                    }
+                }
+            ]
         }
       }
     }


### PR DESCRIPTION
With KrakenD's 2.7 enterprise version the "tiered rate limits" feature was added, that allows to have tiers without requiring additional endpoints to "route" depending on the tier.